### PR TITLE
Inspect metadata instead of serializing it

### DIFF
--- a/lib/disco_log/discord/context.ex
+++ b/lib/disco_log/discord/context.ex
@@ -166,7 +166,7 @@ defmodule DiscoLog.Discord.Context do
     Keyword.put(
       fields,
       :metadata,
-      {Encoder.encode!(metadata, pretty: true), filename: "metadata.json"}
+      {inspect(metadata, pretty: true), filename: "metadata.ex"}
     )
   end
 


### PR DESCRIPTION
Hi and thank you for this amazing library 👋 

I've recently started using disco log in one of my projects and, as it often goes, one of the very first struggles is metadata. In particular, metadata is usually serialized to json and as we all know not every Elixir term is serializable. 

But with the way it's implemented in DiscoLog, I don't think it has to be serialized to json? It attaches metadata as a file attachment, and it can very well use `inspect/2` and put it into `.ex` file instead of `.json`. Discord will even properly apply code highlighting to it:
 
![image](https://github.com/user-attachments/assets/64f93033-9fbd-4f60-b571-a51f35252bda)

WDYT?