### PR TITLE
feat: do not limit length of inspected metadata

### DIFF
--- a/dev.exs
+++ b/dev.exs
@@ -56,6 +56,7 @@ defmodule DemoWeb.PageController do
     <div><a href="/new_user">Generate a new user log</a></div>
     <div><a href="/user_upgrade">Generate a pay plan log</a></div>
     <div><a href="/extra">Generate a log with attachments</a></div>
+    <div><a href="/long_extra">Generate a log with long attachment</a></div>
 
     <h3>Should not generate errors</h3>
     <div><a href="/404">404 Not found</a></div>
@@ -122,6 +123,19 @@ defmodule DemoWeb.LogController do
         and: "more",
         stuff: "here"
       }
+    )
+
+    conn
+    |> redirect(to: "/")
+  end
+
+  def call(conn, :long_extra) do
+    Logger.info(
+      """
+      ✨ Extra Long Log !
+      📎 With `conn` as attachment
+      """,
+      extra: conn
     )
 
     conn
@@ -227,6 +241,7 @@ defmodule DemoWeb.Router do
     get("/new_user", DemoWeb.LogController, :new_user)
     get("/user_upgrade", DemoWeb.LogController, :user_upgrade)
     get("/extra", DemoWeb.LogController, :extra)
+    get("/long_extra", DemoWeb.LogController, :long_extra)
 
     live("/liveview/mount_error", DemoWeb.MountErrorLive, :index)
     live("/liveview/multi_error/raise", DemoWeb.MultiErrorLive, :raise)

--- a/lib/disco_log/discord/context.ex
+++ b/lib/disco_log/discord/context.ex
@@ -174,7 +174,7 @@ defmodule DiscoLog.Discord.Context do
     Keyword.put(
       fields,
       :metadata,
-      {inspect(metadata, pretty: true), filename: "metadata.ex"}
+      {serialize_metadata(metadata), filename: "metadata.ex"}
     )
   end
 
@@ -192,5 +192,12 @@ defmodule DiscoLog.Discord.Context do
     response
     |> Enum.map(& &1["id"])
     |> Enum.map(&Discord.Client.delete_message(config, channel_id, &1))
+  end
+
+  defp serialize_metadata(metadata) do
+    metadata
+    |> inspect(pretty: true, limit: :infinity, printable_limit: :infinity)
+    # 8MB is the max file attachment limit
+    |> String.byte_slice(0, 8_000_000)
   end
 end


### PR DESCRIPTION
### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests

One of the downsides of https://github.com/mrdotb/disco-log/pull/20 I ran into is that by default `inspect/2` truncates items after a certain limit. This PR sets the limit to `:infinity` and adds a test.

There is also `printable_limit` for binaries and charlists, but I'm now sure it's a good idea to change that one. Let me know what you think!  