### PR TITLE
chore: fix 1.18 warning in test code

### DIFF
--- a/test/disco_log/logger_handler_test.exs
+++ b/test/disco_log/logger_handler_test.exs
@@ -353,12 +353,12 @@ defmodule DiscoLog.LoggerHandlerTest do
       end)
 
       run_and_catch_exit(test_genserver, fn ->
-        invalid_function()
+        raise "Hello World"
       end)
 
       assert_receive {^ref, error}
-      assert error.kind == to_string(FunctionClauseError)
-      assert error.reason == "no function clause matching in NaiveDateTime.from_erl/3"
+      assert error.kind == to_string(RuntimeError)
+      assert error.reason == "Hello World"
     end
 
     test "GenServer timeout is reported", %{test_genserver: test_genserver} do
@@ -388,9 +388,5 @@ defmodule DiscoLog.LoggerHandlerTest do
 
   defp run_and_catch_exit(test_genserver_pid, fun) do
     catch_exit(DiscoLog.TestGenServer.run(test_genserver_pid, fun))
-  end
-
-  defp invalid_function do
-    NaiveDateTime.from_erl({}, {}, {})
   end
 end


### PR DESCRIPTION
### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message

Elixir 1.18 is much more strict about invalid code, even in tests.
