### PR TITLE
feat: add bread crumbs in error context

### DIFF
--- a/dev.exs
+++ b/dev.exs
@@ -31,6 +31,10 @@ Application.put_env(:disco_log, DemoWeb.Endpoint,
   ]
 )
 
+defmodule ErrorWithBreadcrumbs do
+  defexception [:message, :bread_crumbs]
+end
+
 defmodule DemoWeb.PageController do
   import Plug.Conn
 
@@ -45,6 +49,7 @@ defmodule DemoWeb.PageController do
     <div><a href="/noroute">Raise NoRouteError from a controller</a></div>
     <div><a href="/exception">Generate Exception</a></div>
     <div><a href="/exit">Generate Exit</a></div>
+    <div><a href="/exception_with_bread_crumbs">Generate Exception with a bread crumbs</a></div>
 
     <h3>Liveview</h3>
     <div><a href="/liveview/mount_error">Generate LiveView mount error</a></div>
@@ -69,6 +74,11 @@ defmodule DemoWeb.PageController do
 
   def call(_conn, :exception) do
     raise "This is a controller exception"
+  end
+
+  def call(_conn, :exception_with_bread_crumbs) do
+    bread_crumbs = ["bread crumb 1", "bread crumb 2"]
+    raise ErrorWithBreadcrumbs, message: "test", bread_crumbs: bread_crumbs
   end
 
   def call(_conn, :exit) do
@@ -237,6 +247,7 @@ defmodule DemoWeb.Router do
     get("/noroute", DemoWeb.PageController, :noroute)
     get("/exception", DemoWeb.PageController, :exception)
     get("/exit", DemoWeb.PageController, :exit)
+    get("/exception_with_bread_crumbs", DemoWeb.PageController, :exception_with_bread_crumbs)
 
     get("/new_user", DemoWeb.LogController, :new_user)
     get("/user_upgrade", DemoWeb.LogController, :user_upgrade)

--- a/lib/disco_log/error.ex
+++ b/lib/disco_log/error.ex
@@ -33,6 +33,11 @@ defmodule DiscoLog.Error do
         do: "#{source.module}.#{source.function}/#{source.arity}",
         else: "nofunction"
 
+    context =
+      if bread_crumbs = get_bread_crumbs(exception),
+        do: Map.put(context, "bread_crumbs", bread_crumbs),
+        else: context
+
     %Error{
       kind: kind,
       reason: reason,
@@ -42,6 +47,14 @@ defmodule DiscoLog.Error do
       stacktrace: stacktrace,
       fingerprint: fingerprint(kind, source_line, source_function)
     }
+  end
+
+  defp get_bread_crumbs(exception) do
+    case exception do
+      {_kind, exception} -> get_bread_crumbs(exception)
+      %{bread_crumbs: bread_crumbs} -> bread_crumbs
+      _other -> nil
+    end
   end
 
   defp normalize_exception(%struct{} = ex, _stacktrace) when is_exception(ex) do

--- a/test/disco_log/error_test.exs
+++ b/test/disco_log/error_test.exs
@@ -78,6 +78,18 @@ defmodule DiscoLog.ErrorTest do
 
       assert error1.fingerprint == error2.fingerprint
     end
+
+    test "includes bread crumbs in the context if present" do
+      bread_crumbs = ["bread crumb 1", "bread crumb 2"]
+
+      %Error{} =
+        error =
+        build_error(fn ->
+          raise ErrorWithBreadcrumbs, message: "test", bread_crumbs: bread_crumbs
+        end)
+
+      assert error.context["bread_crumbs"] == bread_crumbs
+    end
   end
 
   describe inspect(&Error.hash/1) do

--- a/test/support/error_with_breadcrumbs.ex
+++ b/test/support/error_with_breadcrumbs.ex
@@ -1,0 +1,3 @@
+defmodule ErrorWithBreadcrumbs do
+  defexception [:message, :bread_crumbs]
+end


### PR DESCRIPTION
Add the bread crumbs used by ash and sploade like in [error-tracker](https://github.com/elixir-error-tracker/error-tracker/commit/428f4c78d7450086f01958465f89bd511edfadbc) [more details](https://bsky.app/profile/zachdaniel.dev/post/3l7qsyil4pg2c).

### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [x] Features include unit/acceptance tests
