### PR TITLE
fix(presence): do not expect 101 Upgrade response to have data

### DIFF
--- a/lib/disco_log/websocket_client.ex
+++ b/lib/disco_log/websocket_client.ex
@@ -17,7 +17,7 @@ defmodule DiscoLog.WebsocketClient do
   defdelegate connect(host, port, path), to: @adapter
 
   @callback boil_message_to_frame(client :: t(), message :: any()) ::
-              {:ok, t(), any()}
+              {:ok, t(), Mint.WebSocket.frame() | nil}
               | {:error, Mint.HTTP.t(), Mint.Types.error(), [Mint.Types.response()]}
               | {:error, Mint.HTTP.t(), Mint.Websocket.error()}
               | {:error, Mint.WebSocket.t(), any()}
@@ -60,6 +60,8 @@ defmodule DiscoLog.WebsocketClient do
       {:ok, :closed_by_server, reason}
     end
   end
+
+  defp handle_frame(client, nil), do: {:ok, client, nil}
 
   defp ack_server_closure(client) do
     with {:ok, client} <- send_frame(client, :close),

--- a/test/disco_log/presence_test.exs
+++ b/test/disco_log/presence_test.exs
@@ -61,6 +61,16 @@ defmodule DiscoLog.PresenceTest do
       %{client: client, pid: pid}
     end
 
+    test "Connect: no immediate Hello event", %{pid: pid} do
+      WebsocketClient.Mock
+      |> expect(:boil_message_to_frame, fn %WebsocketClient{} = client, {:ssl, :fake_upgrade} ->
+        {:ok, client, nil}
+      end)
+
+      send(pid, {:ssl, :fake_upgrade})
+      :sys.get_status(pid)
+    end
+
     test "Hello: sends Identify", %{pid: pid} do
       WebsocketClient.Mock
       |> expect(:boil_message_to_frame, fn %WebsocketClient{} = client, {:ssl, :fake_hello} ->


### PR DESCRIPTION
### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [x] Bug fixes include regression tests

For me, `Hello` event always comes in the same tcp message as initial 101 Upgrade response, but apparently this isn't [always the case](https://github.com/mrdotb/disco-log/issues/35) A simple fix is to make data frame processing optional when handling the response. That should be enough, but there is always an option for the future to account for multiple data frames in a single message.