### PR TITLE
fix(presence): handle non-101 response status for ws upgrade request

### DIFF
--- a/lib/disco_log/presence.ex
+++ b/lib/disco_log/presence.ex
@@ -152,6 +152,9 @@ defmodule DiscoLog.Presence do
       {:ok, client, msg} ->
         {:noreply, %{state | websocket_client: client}, {:continue, {:event, msg}}}
 
+      {:error, _conn, %Mint.WebSocket.UpgradeFailureError{} = error} ->
+        {:stop, {:shutdown, error}, state}
+
       other ->
         {:stop, other, state}
     end

--- a/lib/disco_log/websocket_client.ex
+++ b/lib/disco_log/websocket_client.ex
@@ -19,7 +19,7 @@ defmodule DiscoLog.WebsocketClient do
   @callback boil_message_to_frame(client :: t(), message :: any()) ::
               {:ok, t(), Mint.WebSocket.frame() | nil}
               | {:error, Mint.HTTP.t(), Mint.Types.error(), [Mint.Types.response()]}
-              | {:error, Mint.HTTP.t(), Mint.Websocket.error()}
+              | {:error, Mint.HTTP.t(), Mint.WebSocket.error()}
               | {:error, Mint.WebSocket.t(), any()}
               | :unknown
   defdelegate boil_message_to_frame(client, message), to: @adapter

--- a/lib/disco_log/websocket_client/impl.ex
+++ b/lib/disco_log/websocket_client/impl.ex
@@ -33,10 +33,10 @@ if Code.ensure_loaded?(Mint.WebSocket) do
     def close(%WebsocketClient{conn: conn}), do: Mint.HTTP.close(conn)
 
     defp handle_tcp_message(%WebsocketClient{conn: conn, ref: ref} = client, [
-           {:status, ref, 101},
+           {:status, ref, status},
            {:headers, ref, headers} | frames
          ]) do
-      with {:ok, conn, websocket} <- Mint.WebSocket.new(conn, ref, 101, headers) do
+      with {:ok, conn, websocket} <- Mint.WebSocket.new(conn, ref, status, headers) do
         client = %{client | conn: conn, websocket: websocket}
 
         if data_frame = Enum.find(frames, &match?({:data, ^ref, _}, &1)) do


### PR DESCRIPTION
### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [x] Bug fixes include regression tests

So this happened, Gateway API return 520 HTTP response code when we were expecting 101:

<details>

<summary> Stacktrace </summary>

```
17:30:26.435 [error] GenServer {DiscoLog.Registry, DiscoLog.Presence} terminating
** (FunctionClauseError) no function clause matching in DiscoLog.WebsocketClient.Impl.handle_tcp_message/2
    (disco_log 0.7.0) lib/disco_log/websocket_client/impl.ex:35: DiscoLog.WebsocketClient.Impl.handle_tcp_message(
        %DiscoLog.WebsocketClient{
            conn: %Mint.HTTP1{
                host: "gateway.discord.gg",
                port: 443,
                request: nil,
                streaming_request: nil,
                socket: {:sslsocket, {:gen_tcp, #Port<0.10>, :tls_connection, :undefined},
                [#PID<0.1414.0>, #PID<0.1413.0>]},
                transport: Mint.Core.Transport.SSL,
                mode: :active,
                scheme_as_string: "https",
                case_sensitive_headers: false,
                requests: {[], []},
                state: :open,
                buffer: "",
                proxy_headers: [],
                private: %{
                    scheme: :wss,
                    extensions: [],
                    sec_websocket_key: "UYJ/ENSZJuJOTestXHMlFQ=="
                },
                log: false
            },
            websocket: nil,
            ref: #Reference<0.2897520450.2679635969.150536>,
            state: :open
        },
        [
            {:status, #Reference<0.2897520450.2679635969.150536>, 520},
            {:headers, #Reference<0.2897520450.2679635969.150536>, [
                {"date", "Thu, 02 Jan 2025 17:30:26 GMT"},
                {"content-type", "text/plain; charset=UTF-8"},
                {"content-length", "15"},
                {"connection", "keep-alive"},
                {"report-to", "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=d3om%2Fp%2BIejMlR5i6YOIkt38AuNXjFTVVVxx0zyaYr84a7Bb5Q3%2BRSYN61Bx0sYS%2B7H%2Fi0aPv3lHBfld7NVd9Cy1n7IXsRGl%2BkEJRWVO34NpkMRASfZuqtYEEj9G3qo%2BjqfUCgg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"},
                {"nel", "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"},
                {"strict-transport-security", "max-age=31536000; includeSubDomains; preload"},
                {"x-content-type-options", "nosniff"},
                {"x-frame-options", "SAMEORIGIN"},
                {"referrer-policy", "same-origin"},
                {"cache-control", "private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0"},
                {"expires", "Thu, 01 Jan 1970 00:00:01 GMT"},
                {"server", "cloudflare"},
                {"cf-ray", "8fbc79fe8860faa6-SJC"}
            ]},
            {:data, #Reference<0.2897520450.2679635969.150536>, "error code: 520"},
            {:done, #Reference<0.2897520450.2679635969.150536>}
        ]
    )
    (disco_log 0.7.0) lib/disco_log/websocket_client.ex:45: DiscoLog.WebsocketClient.handle_message/2
    (disco_log 0.7.0) lib/disco_log/presence.ex:145: DiscoLog.Presence.handle_info/2
    (stdlib 6.2) gen_server.erl:2345: :gen_server.try_handle_info/3
    (stdlib 6.2) gen_server.erl:2433: :gen_server.handle_msg/6
    (stdlib 6.2) proc_lib.erl:329: :proc_lib.init_p_do_apply/3

Last message: {
    :ssl,
    {:sslsocket, {:gen_tcp, #Port<0.10>, :tls_connection, :undefined},
    [#PID<0.1414.0>, #PID<0.1413.0>]},
    "HTTP/1.1 520 \r\n
    Date: Thu, 02 Jan 2025 17:30:26 GMT\r\n
    Content-Type: text/plain; charset=UTF-8\r\n
    Content-Length: 15\r\n
    Connection: keep-alive\r\n
    Report-To: {\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=d3om%2Fp%2BIejMlR5i6YOIkt38AuNXjFTVVVxx0zyaYr84a7Bb5Q3%2BRSYN61Bx0sYS%2B7H%2Fi0aPv3lHBfld7NVd9Cy1n7IXsRGl%2BkEJRWVO34NpkMRASfZuqtYEEj9G3qo%2BjqfUCgg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}\r\n
    NEL: {\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}\r\n
    Strict-Transport-Security: max-age=31536000; includeSubDomains; preload\r\n
    X-Content-Type-Options: nosniff\r\n
    X-Frame-Options: SAMEORIGIN\r\n
    Referrer-Policy: same-origin\r\n
    Cache-Control: private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0\r\n
    Expires: Thu, 01 Jan 1970 00:00:01 GMT\r\n
    Server: cloudflare\r\n
    CF-RAY: 8fbc79fe8860faa6-SJC\r\n\r\n
    error code: 520"
}
```

</details>

In this case, we can just shut down the process and attempt again. To do so, we don't match on `status`, but instead pass it to `Mint.WebSocket` and let it return an error. Finally, `Presence` process will shut down if it encounters this error.