### PR TITLE
feat(presence): set basic presence status 💅

### DIFF
--- a/lib/disco_log/config.ex
+++ b/lib/disco_log/config.ex
@@ -102,6 +102,11 @@ defmodule DiscoLog.Config do
       type: :atom,
       default: DiscoLog,
       doc: "Name of the supervisor process running DiscoLog"
+    ],
+    presence_status: [
+      type: :string,
+      default: "🪩 Disco Logging",
+      doc: "A message to display as the bot's status when presence is enabled"
     ]
   ]
 

--- a/lib/disco_log/supervisor.ex
+++ b/lib/disco_log/supervisor.ex
@@ -49,7 +49,8 @@ defmodule DiscoLog.Supervisor do
         {Presence,
          supervisor_name: config.supervisor_name,
          discord_config: config.discord_config,
-         discord: config.discord}
+         discord: config.discord,
+         presence_status: config.presence_status}
       ]
     else
       []


### PR DESCRIPTION
### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [x] Features include unit/acceptance tests

Context: https://github.com/mrdotb/disco-log/pull/30#issuecomment-2565245168

After looking at what presence features are available to us, I don't think we can do all that much. Most of the interesting features [aren't available for bots](https://discord.com/developers/docs/events/gateway-events#activity-object-activity-structure). So for this PR I went with a basic custom status:
![image](https://github.com/user-attachments/assets/0670a782-343a-4ef7-9630-235bef87a8a9)
![image](https://github.com/user-attachments/assets/898e67be-7fd4-4830-8a43-9d4b6fbb54f4)


Open to other messages of course 😅 

For avatar, I don't think it's a part of the presence, so users will have to upload it manually on the developer portal.

For uptime, I didn't implement it just yet. It's definitely a cool thing to have for a single-bot single-node setup, but if a user users bot for multiple projects running on multiple nodes, they all will constantly overwrite each other. Let me know what you think!

