### PR TITLE
feat(go-to-repo): create a link to the repo viewer on discord report

### DIFF
--- a/config/dev.examples.exs
+++ b/config/dev.examples.exs
@@ -16,7 +16,11 @@ config :disco_log,
   enable_logger: true,
   instrument_oban: true,
   instrument_phoenix: true,
-  metadata: [:extra]
+  metadata: [:extra],
+  enable_go_to_repo: true,
+  repo_url: "https://github.com/mrdotb/disco-log/blob",
+  # a real git sha is better but for testing purposes you can use a branch
+  git_sha: "main"
 
 config :logger,
   # backends: [],

--- a/lib/disco_log.ex
+++ b/lib/disco_log.ex
@@ -6,7 +6,7 @@ defmodule DiscoLog do
     config = config || DiscoLog.Config.read!()
     context = Map.merge(DiscoLog.Context.get(), given_context)
 
-    error = DiscoLog.Error.new(exception, stacktrace, context, config.otp_app)
+    error = DiscoLog.Error.new(exception, stacktrace, context, config)
     DiscoLog.Client.send_error(error, config)
   end
 end

--- a/lib/disco_log/config.ex
+++ b/lib/disco_log/config.ex
@@ -107,6 +107,27 @@ defmodule DiscoLog.Config do
       type: :string,
       default: "🪩 Disco Logging",
       doc: "A message to display as the bot's status when presence is enabled"
+    ],
+    enable_go_to_repo: [
+      type: :boolean,
+      default: false,
+      doc: "Enable go_to_repo feature?"
+    ],
+    go_to_repo_top_modules: [
+      type: {:list, :string},
+      default: [],
+      doc:
+        "List of top-level modules that are not part of the application spec but code belongs to the app"
+    ],
+    repo_url: [
+      type: :string,
+      default: "",
+      doc: "URL to the git repository viewer"
+    ],
+    git_sha: [
+      type: :string,
+      default: "",
+      doc: "The git SHA of the running app"
     ]
   ]
 

--- a/lib/disco_log/discord/context.ex
+++ b/lib/disco_log/discord/context.ex
@@ -99,27 +99,41 @@ defmodule DiscoLog.Discord.Context do
         **At:** <t:#{System.os_time(:second)}:T>
         **Kind:** `#{error.kind}`
         **Reason:** `#{error.reason}`
-        **Source Line:** `#{error.source_line}`
+        **Source Line:** #{source_line(error)}
         **Source Function:** `#{error.source_function}`
         **Fingerprint:** `#{error.fingerprint}`
       """
-      # Maybe there is something nice to do with embeds fields
-      # https://discordjs.guide/popular-topics/embeds.html#embed-preview
-      # embeds: [
-      #   %{
-      #     fields: [
-      #       %{name: "at", value: "<t:#{System.os_time(:second)}:T>"},
-      #       %{name: "kind", value: backtick_wrap(error.kind)},
-      #       %{name: "reason", value: backtick_wrap(error.reason)},
-      #       %{name: "source_line", value: backtick_wrap(error.source_line)},
-      #       %{name: "source_function", value: backtick_wrap(error.source_function)},
-      #       %{name: "fingerprint", value: backtick_wrap(error.fingerprint)}
-      #     ]
-      #   }
-      # ]
     }
   end
 
+  # source line can be a link to the source code if source_url is set
+  defp source_line(error) do
+    if error.source_url do
+      # we wrap the url with `<>` to prevent an embed preview to be created
+      "[`#{error.source_line}`](<#{error.source_url}>)"
+    else
+      "`#{error.source_line}`"
+    end
+  end
+
+  # Note can we do something nicer using discord embeds ?
+  # defp prepare_error_message(error) do
+  # %{
+  # Maybe there is something nice to do with embeds fields
+  # https://discordjs.guide/popular-topics/embeds.html#embed-preview
+  # embeds: [
+  #   %{
+  #     fields: [
+  #       %{name: "at", value: "<t:#{System.os_time(:second)}:T>"},
+  #       %{name: "kind", value: backtick_wrap(error.kind)},
+  #       %{name: "reason", value: backtick_wrap(error.reason)},
+  #       %{name: "source_line", value: backtick_wrap(error.source_line)},
+  #       %{name: "source_function", value: backtick_wrap(error.source_function)},
+  #       %{name: "fingerprint", value: backtick_wrap(error.fingerprint)}
+  #     ]
+  #   }
+  # ]
+  # end
   # defp backtick_wrap(string), do: "`#{string}`"
 
   defp maybe_put_tag(config, message, context) do

--- a/lib/disco_log/logger_handler.ex
+++ b/lib/disco_log/logger_handler.ex
@@ -142,7 +142,7 @@ defmodule DiscoLog.LoggerHandler do
        )
        when is_exception(exception) and is_list(stacktrace) do
     context = Map.put(Context.get(), :metadata, metadata)
-    error = Error.new(exception, stacktrace, context, config.otp_app)
+    error = Error.new(exception, stacktrace, context, config)
     Client.send_error(error, config)
     :ok
   end
@@ -165,14 +165,14 @@ defmodule DiscoLog.LoggerHandler do
       when type in [:noproc, :timeout] ->
         reason = Exception.format_exit(reason)
         context = Map.put(context, :extra_reason, reason)
-        error = Error.new({"genserver_call", type}, stacktrace, context, config.otp_app)
+        error = Error.new({"genserver_call", type}, stacktrace, context, config)
         Client.send_error(error, config)
 
       _other ->
         context =
           Map.put(context, :extra_info_from_genserver, try_to_parse_message(chardata_message))
 
-        error = Error.new(reason, stacktrace, context, config.otp_app)
+        error = Error.new(reason, stacktrace, context, config)
         Client.send_error(error, config)
     end
 
@@ -341,12 +341,12 @@ defmodule DiscoLog.LoggerHandler do
     case Map.new(report) do
       %{reason: {exception, stacktrace}} when is_exception(exception) and is_list(stacktrace) ->
         context = Map.put(Context.get(), :metadata, metadata)
-        error = Error.new(exception, stacktrace, context, config.otp_app)
+        error = Error.new(exception, stacktrace, context, config)
         Client.send_error(error, config)
 
       %{reason: {reason, stacktrace}} when is_list(stacktrace) ->
         context = Map.put(Context.get(), :metadata, metadata)
-        error = Error.new(reason, stacktrace, context, config.otp_app)
+        error = Error.new(reason, stacktrace, context, config)
         Client.send_error(error, config)
 
       %{reason: reason} ->

--- a/test/disco_log/error_test.exs
+++ b/test/disco_log/error_test.exs
@@ -12,6 +12,7 @@ defmodule DiscoLog.ErrorTest do
       assert error.kind == to_string(RuntimeError)
       assert error.reason == "This is a test"
       assert error.source_line =~ @relative_file_path
+      assert error.source_url =~ @relative_file_path
 
       assert error.source_function ==
                "DiscoLog.ErrorTest.-test &DiscoLog.Error.new/4 exceptions/1-fun-0-/0"
@@ -36,6 +37,8 @@ defmodule DiscoLog.ErrorTest do
         assert error.source_function == "erlang.+/2"
         assert error.source_line == "nofile"
       end
+
+      assert error.source_url =~ @relative_file_path
     end
 
     test "undefined function errors" do
@@ -50,6 +53,7 @@ defmodule DiscoLog.ErrorTest do
       assert error.reason =~ "is undefined or private"
       assert error.source_function == Exception.format_mfa(m, f, Enum.count(a))
       assert error.source_line == "nofile"
+      assert error.source_url == nil
     end
 
     test "throws" do
@@ -60,6 +64,7 @@ defmodule DiscoLog.ErrorTest do
       assert error.kind == "throw"
       assert error.reason == "This is a test"
       assert error.source_line =~ @relative_file_path
+      assert error.source_url =~ @relative_file_path
     end
 
     test "exits" do
@@ -70,6 +75,7 @@ defmodule DiscoLog.ErrorTest do
       assert error.kind == "exit"
       assert error.reason == "This is a test"
       assert error.source_line =~ @relative_file_path
+      assert error.source_url =~ @relative_file_path
     end
 
     test "similar error should have the same fingerprint " do

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -2,6 +2,23 @@ defmodule DiscoLog.Test.Case do
   @moduledoc false
   use ExUnit.CaseTemplate
 
+  @config DiscoLog.Config.validate!(
+            otp_app: :disco_log,
+            token: "mytoken",
+            guild_id: "guild_id",
+            category_id: "category_id",
+            occurrences_channel_id: "occurences_channel_id",
+            occurrences_channel_tags: %{},
+            info_channel_id: "info_channel_id",
+            error_channel_id: "error_channel_id",
+            discord: DiscoLog.DiscordMock,
+            enable_presence: false,
+            enable_go_to_repo: true,
+            go_to_repo_top_modules: ["DiscoLog"],
+            repo_url: "https://github.com/mrdotb/disco-log/blob",
+            git_sha: "main"
+          )
+
   using do
     quote do
       import DiscoLog.Test.Case
@@ -15,10 +32,10 @@ defmodule DiscoLog.Test.Case do
     fun.()
   rescue
     exception ->
-      DiscoLog.Error.new(exception, __STACKTRACE__, %{}, :app_name)
+      DiscoLog.Error.new(exception, __STACKTRACE__, %{}, @config)
   catch
     kind, reason ->
-      DiscoLog.Error.new({kind, reason}, __STACKTRACE__, %{}, :app_name)
+      DiscoLog.Error.new({kind, reason}, __STACKTRACE__, %{}, @config)
   end
 
   @doc """


### PR DESCRIPTION
### checklist
- [x] My commit messages follow the [Conventional Commit Message Format]
- [x] Features include unit/acceptance tests
- [x] Documentation


Testing was harder than expected because the modules defined in exs files (tests and dev.exs ) are not part of the `:disco_log` application because they are interpreted.
When using the `Application.get_application` it call a erlang fn then check value in a [ets table](https://github.com/erlang/otp/blob/OTP-27.2/lib/kernel/src/application_controller.erl#L460)
This same ets table is populated when the application start.
The content of this ets table can be dumped in iex with.
`:ets.tab2list(:ac_tab)`
> loaded app have a list of modules (which are pid) and that's what is used to the the application from a module or a atom (erlang style).

To allow easy development and testing I added a config `go_to_repo_top_modules` which is a list of binary that allow us to pass top module that belongs to our code but are present in exs.
It could also be usefull for disco_log user if for some reason they have a similar case.

I though about other alternative like hooking the Application.get_application or putting the value by myself in the ets table but both seems worst than what I did.
