### PR TITLE
fix(presence): handle receiving no frames from tcp

### DIFF
--- a/lib/disco_log/websocket_client.ex
+++ b/lib/disco_log/websocket_client.ex
@@ -62,6 +62,7 @@ defmodule DiscoLog.WebsocketClient do
   end
 
   defp handle_frame(client, nil), do: {:ok, client, nil}
+  defp handle_frame(client, []), do: {:ok, client, nil}
 
   defp ack_server_closure(client) do
     with {:ok, client} <- send_frame(client, :close),


### PR DESCRIPTION
### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message

Fixing https://github.com/mrdotb/disco-log/issues/40

Apparently, when we receive a tcp message there can be no full frames in there to decode!

We could make a generic `defp handle_frame(client, _), do: {:ok, client, nil}` clause to handle any unexpected frame shape, but I'd personally love to see what else can come up before we make the final call of what's expected and what is not. In the end, the cost of this is a genserver restart and an error message.