### PR TITLE
fix: genserver stop struct remove logger handler

### DIFF
--- a/lib/disco_log/error.ex
+++ b/lib/disco_log/error.ex
@@ -59,6 +59,16 @@ defmodule DiscoLog.Error do
     {to_string(struct), Exception.message(ex)}
   end
 
+  defp normalize_exception({kind, reason}, _stacktrace)
+       when is_binary(kind) and is_binary(reason) do
+    {kind, reason}
+  end
+
+  defp normalize_exception({kind, reason}, _stacktrace)
+       when is_atom(kind) and is_binary(reason) do
+    {to_string(kind), reason}
+  end
+
   defp normalize_exception({kind, ex}, stacktrace) do
     case Exception.normalize(kind, ex, stacktrace) do
       %struct{} = ex ->


### PR DESCRIPTION
### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [x] Bug fixes include regression tests

Context:
The presence genserver have some transient ssl error which terminated the genserver with a `{:stop, %Mint.HTTP1{}, state}`

Stopping the server with a struct was breaking the logger handler cause It did not expect a struct here.
I edited the logger handler part that deal with genserver error.
I use a more generic `genserver` error kind what I put before was no really a kind but a reason
The bad return value error look like that now
```elixir
%DiscoLog.Error{
  kind: "genserver",
  reason: "** (stop) bad return value: :testing_throw",
  source_line: "nofile",
  source_function: "nofunction",
  context: %{
    metadata: %{},
    extra_info_from_message: %{
      last_message: "{:run, #Function<41.8045411/0 in DiscoLog.LoggerHandlerTest.\"test with a crashing GenServer a GenServer throw is reported\"/1>}",
      genserver_state: "[]"
    },
    extra_info_from_genserver: %{
      message: "GenServer %{} terminating: ** (stop) bad return value: :testing_throw",
      state: "[]",
      last_message: "{:run, #Function<41.8045411/0 in DiscoLog.LoggerHandlerTest.\"test with a crashing GenServer a GenServer throw is reported\"/1>}"
    }
  },
  stacktrace: %DiscoLog.Stacktrace{lines: []},
  fingerprint: "B915D5BF5886DCEB",
  source_url: nil
}
```

The new `normalize_exception` fn clause remove some type warning on `Error.new` in the logger handler.



