### PR TITLE
fix(presence): handle ssl_closed message

### DIFF
--- a/lib/disco_log/presence.ex
+++ b/lib/disco_log/presence.ex
@@ -162,6 +162,9 @@ defmodule DiscoLog.Presence do
       {:error, _conn, %Mint.WebSocket.UpgradeFailureError{} = error} ->
         {:stop, {:shutdown, error}, state}
 
+      {:error, _conn, %Mint.TransportError{reason: :closed} = error} ->
+        {:stop, {:shutdown, error}, state}
+
       other ->
         {:stop, other, state}
     end
@@ -170,6 +173,7 @@ defmodule DiscoLog.Presence do
   @impl GenServer
   def terminate({:shutdown, {:closed_by_server, _}}, _state), do: :ok
   def terminate({:shutdown, :closed_by_client}, _state), do: :ok
+  def terminate({:shutdown, %Mint.TransportError{}}, _state), do: :ok
 
   def terminate(_other, %__MODULE__{websocket_client: %{state: :open, websocket: %{}} = client}) do
     WebsocketClient.begin_disconnect(client, 1000, "graceful disconnect")


### PR DESCRIPTION
### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [x] Bug fixes include regression tests

Closes #45

One more message we can receive from a socket! This time it just closed without warning. Still would rather add a specific branch to see what else is out there.
