### PR TITLE
feat: dynamic tags

### DIFF
--- a/config/dev.examples.exs
+++ b/config/dev.examples.exs
@@ -6,11 +6,6 @@ config :disco_log,
   guild_id: "",
   category_id: "",
   occurrences_channel_id: "",
-  occurrences_channel_tags: %{
-    "plug" => "",
-    "live_view" => "",
-    "oban" => ""
-  },
   info_channel_id: "",
   error_channel_id: "",
   enable_logger: true,

--- a/config/test.exs
+++ b/config/test.exs
@@ -7,12 +7,6 @@ config :disco_log,
   guild_id: "",
   category_id: "",
   occurrences_channel_id: "",
-  occurrences_channel_tags: %{
-    "plug" => "",
-    "phoenix" => "",
-    "liveview" => "",
-    "oban" => ""
-  },
   info_channel_id: "",
   error_channel_id: "",
   discord: DiscoLog.DiscordMock,

--- a/guides/advanced-configuration.md
+++ b/guides/advanced-configuration.md
@@ -31,11 +31,6 @@ config :my_app, DiscoLog,
     token: "server_A_secret_token"
     category_id: "1234567891011121314",
     occurrences_channel_id: "1234567891011121314",
-    occurrences_channel_tags: %{
-      "plug" => "1234567891011121314",
-      "live_view" => "1234567891011121314",
-      "oban" => "1234567891011121314"
-    },
     info_channel_id: "1234567891011121314",
     error_channel_id: "1234567891011121314",
     supervisor_name: MyApp.DiscoLog.ServerA
@@ -45,11 +40,6 @@ config :my_app, DiscoLog,
     token: "server_B_secret_token"
     category_id: "9876543210123456789",
     occurrences_channel_id: "9876543210123456789",
-    occurrences_channel_tags: %{
-      "plug" => "9876543210123456789",
-      "live_view" => "9876543210123456789",
-      "oban" => "9876543210123456789"
-    },
     info_channel_id: "9876543210123456789",
     error_channel_id: "9876543210123456789",
     supervisor_name: MyApp.DiscoLog.ServerB

--- a/lib/disco_log/client.ex
+++ b/lib/disco_log/client.ex
@@ -7,6 +7,8 @@ defmodule DiscoLog.Client do
   alias DiscoLog.Storage
 
   def send_error(%Error{} = error, config) do
+    config = put_dynamic_tags(config)
+
     with {:ok, %Error{} = error} <- maybe_call_before_send(error, config.before_send),
          :ok <- maybe_dedupe(error, config) do
       do_send_error(error, config)
@@ -92,5 +94,11 @@ defmodule DiscoLog.Client do
     :before_send must be an anonymous function or a {module, function} tuple, got: \
     #{inspect(other)}\
     """
+  end
+
+  defp put_dynamic_tags(config) do
+    update_in(config, [:discord_config, Access.key!(:occurrences_channel_tags)], fn _ ->
+      Storage.get_tags(config.supervisor_name)
+    end)
   end
 end

--- a/lib/disco_log/config.ex
+++ b/lib/disco_log/config.ex
@@ -27,11 +27,6 @@ defmodule DiscoLog.Config do
       required: true,
       doc: "Forum channel ID for error occurrences"
     ],
-    occurrences_channel_tags: [
-      type: {:map, :string, :string},
-      required: true,
-      doc: "Map with IDs for \"plug\", \"live_view\" and \"oban\" tags"
-    ],
     info_channel_id: [
       type: :string,
       required: true,

--- a/lib/disco_log/discord.ex
+++ b/lib/disco_log/discord.ex
@@ -36,6 +36,8 @@ defmodule DiscoLog.DiscordBehaviour do
   @callback delete_threads(config(), channel_id :: String.t()) :: list(any)
 
   @callback get_gateway(config()) :: {:ok, String.t()} | {:error, String.t()}
+
+  @callback list_tags(config(), occurence_channel_id :: String.t()) :: map()
 end
 
 defmodule DiscoLog.Discord do
@@ -76,4 +78,7 @@ defmodule DiscoLog.Discord do
 
   @impl true
   defdelegate get_gateway(config), to: Discord.Context
+
+  @impl true
+  defdelegate list_tags(config, occurence_channel_id), to: Discord.Context
 end

--- a/lib/disco_log/discord/client.ex
+++ b/lib/disco_log/discord/client.ex
@@ -131,6 +131,16 @@ defmodule DiscoLog.Discord.Client do
     end
   end
 
+  def get_channel(config, channel_id) do
+    case Req.get!(client(config), url: "/channels/#{channel_id}") do
+      %Req.Response{status: 200, body: body} ->
+        {:ok, body}
+
+      _ ->
+        {:error, "Failed to get channel"}
+    end
+  end
+
   def client(config) do
     Req.new(
       base_url: @base_url,

--- a/lib/disco_log/discord/context.ex
+++ b/lib/disco_log/discord/context.ex
@@ -67,6 +67,13 @@ defmodule DiscoLog.Discord.Context do
     end
   end
 
+  def list_tags(config, occurrences_channel_id) do
+    {:ok, response} =
+      Discord.Client.get_channel(config, occurrences_channel_id)
+
+    for %{"id" => id, "name" => name} <- response["available_tags"], into: %{}, do: {name, id}
+  end
+
   defp prepare_occurrence_thread_fields(config, error) do
     [
       payload_json:

--- a/lib/mix/tasks/disco_log.create.ex
+++ b/lib/mix/tasks/disco_log.create.ex
@@ -46,7 +46,6 @@ defmodule Mix.Tasks.DiscoLog.Create do
         guild_id: "#{config.guild_id}",
         category_id: "#{category["id"]}",
         occurrences_channel_id: "#{occurrence["id"]}",
-        occurrences_channel_tags: %{#{Enum.map_join(occurrence["available_tags"], ", ", fn tag -> "\"#{tag["name"]}\" => \"#{tag["id"]}\"" end)}},
         info_channel_id: "#{info["id"]}",
         error_channel_id: "#{error["id"]}"
       """)

--- a/test/disco_log/application_test.exs
+++ b/test/disco_log/application_test.exs
@@ -10,6 +10,7 @@ defmodule DiscoLog.ApplicationTest do
   setup_all do
     DiscoLog.DiscordMock
     |> Mox.stub(:list_occurrence_threads, fn _, _ -> [] end)
+    |> Mox.stub(:list_tags, fn _, _ -> %{} end)
     |> Mox.stub(:get_gateway, fn _ -> {:ok, "wss://example.com"} end)
 
     Mox.stub(DiscoLog.WebsocketClient.Mock, :connect, fn _, _, _ -> {:ok, %WebsocketClient{}} end)

--- a/test/disco_log/config_test.exs
+++ b/test/disco_log/config_test.exs
@@ -10,11 +10,6 @@ defmodule DiscoLog.ConfigTest do
     guild_id: "guild_id",
     category_id: "category_id",
     occurrences_channel_id: "occurrences_channel_id",
-    occurrences_channel_tags: %{
-      "plug" => "plug_tag_id",
-      "live_view" => "live_view_tag_id",
-      "oban" => "oban_tag_id"
-    },
     info_channel_id: "info_channel_id",
     error_channel_id: "error_channel_id",
     enable: true,

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -8,7 +8,6 @@ defmodule DiscoLog.Test.Case do
             guild_id: "guild_id",
             category_id: "category_id",
             occurrences_channel_id: "occurences_channel_id",
-            occurrences_channel_tags: %{},
             info_channel_id: "info_channel_id",
             error_channel_id: "error_channel_id",
             discord: DiscoLog.DiscordMock,
@@ -76,7 +75,6 @@ defmodule DiscoLog.Test.Case do
         guild_id: "guild_id",
         category_id: "category_id",
         occurrences_channel_id: "occurences_channel_id",
-        occurrences_channel_tags: %{},
         info_channel_id: "info_channel_id",
         error_channel_id: "error_channel_id",
         discord: DiscoLog.DiscordMock,
@@ -85,7 +83,9 @@ defmodule DiscoLog.Test.Case do
       |> Keyword.merge(Map.fetch!(context, :config))
       |> DiscoLog.Config.validate!()
 
-    Mox.stub(DiscoLog.DiscordMock, :list_occurrence_threads, fn _, _ -> [] end)
+    DiscoLog.DiscordMock
+    |> Mox.stub(:list_occurrence_threads, fn _, _ -> [] end)
+    |> Mox.stub(:list_tags, fn _, _ -> %{} end)
 
     {:ok, _pid} = start_supervised({DiscoLog.Supervisor, config})
 


### PR DESCRIPTION
### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [x] Features include unit/acceptance tests

Eventually I would love to allow users to use any custom tags for the errors. The first step to that is to dynamically retrieve available tags and store them in `Storage` process (or rather, in part of the Registry that belongs to the `Storage`). `DiscoLog.Client` module will retrieve available tags from the storage and put them into discord config before it passes said config and an error further.

One implication of this is that we don't need `occurrences_channel_tags` configuration option anymore. In this PR I hard-deleted it, making it a backwards incompatible change, but we can make it a deprecation instead.