### PR TITLE
fix: correct clause in SSL closed message and handle GenServer logger crash

### DIFF
--- a/lib/disco_log/presence.ex
+++ b/lib/disco_log/presence.ex
@@ -162,7 +162,7 @@ defmodule DiscoLog.Presence do
       {:error, _conn, %Mint.WebSocket.UpgradeFailureError{} = error} ->
         {:stop, {:shutdown, error}, state}
 
-      {:error, _conn, %Mint.TransportError{reason: :closed} = error} ->
+      {:error, _conn, %Mint.TransportError{reason: :closed} = error, []} ->
         {:stop, {:shutdown, error}, state}
 
       other ->

--- a/test/disco_log/presence_test.exs
+++ b/test/disco_log/presence_test.exs
@@ -339,7 +339,7 @@ defmodule DiscoLog.PresenceTest do
 
       WebsocketClient.Mock
       |> expect(:boil_message_to_frame, fn _client, {:ssl, :fake_ssl_closed} ->
-        {:error, nil, %Mint.TransportError{reason: :closed}}
+        {:error, nil, %Mint.TransportError{reason: :closed}, []}
       end)
 
       send(pid, {:ssl, :fake_ssl_closed})

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -83,7 +83,12 @@ defmodule DiscoLog.Test.Case do
       |> Keyword.merge(Map.fetch!(context, :config))
       |> DiscoLog.Config.validate!()
 
+    Mox.stub(DiscoLog.WebsocketClient.Mock, :connect, fn _, _, _ ->
+      {:ok, struct(DiscoLog.WebsocketClient, %{})}
+    end)
+
     DiscoLog.DiscordMock
+    |> Mox.stub(:get_gateway, fn _config -> {:ok, "wss://gateway.discord.gg"} end)
     |> Mox.stub(:list_occurrence_threads, fn _, _ -> [] end)
     |> Mox.stub(:list_tags, fn _, _ -> %{} end)
 


### PR DESCRIPTION
- Fixes a clause error in the SSL closed message introduced in #45
- Addresses a GenServer crash that was breaking the logger handler

### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [x] Bug fixes include regression tests
