### PR TITLE
refactor(presence): account for handling multiple data frames at once

### DIFF
--- a/test/disco_log/logger_handler_test.exs
+++ b/test/disco_log/logger_handler_test.exs
@@ -559,7 +559,7 @@ defmodule DiscoLog.LoggerHandlerTest do
       ref2 = make_ref()
 
       DiscoLog.WebsocketClient.Mock
-      |> expect(:boil_message_to_frame, fn _client, {:ssl, :fake_ssl_closed} ->
+      |> expect(:boil_message_to_frames, fn _client, {:ssl, :fake_ssl_closed} ->
         {:error, nil, %Mint.TransportError{reason: :closed}}
       end)
 


### PR DESCRIPTION
### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [x] Bug fixes include regression tests

closes https://github.com/mrdotb/disco-log/issues/65

Changes:
1. `WebsocketClient.boil_message_to_frame` is renamed to `boil_message_to_frames` and changed to return all decoded data frames
2. `WebsocketClient.handle_message` will look through frames for a close message and if there is one, it will close the connection. If there isn't, it'll return decoded data frames to the caller.
3. `Presence` will iterate through all received data frames through a chain of `:continue` callbacks.