### PR TITLE
fix: missing mint structs when using disco-log without presence

### DIFF
--- a/lib/disco_log/presence.ex
+++ b/lib/disco_log/presence.ex
@@ -132,10 +132,11 @@ defmodule DiscoLog.Presence do
       {:ok, client, messages} ->
         {:noreply, %{state | websocket_client: client}, {:continue, {:event, messages}}}
 
-      {:error, _conn, %Mint.WebSocket.UpgradeFailureError{} = error} ->
+      {:error, _conn, error} when is_struct(error, Mint.WebSocket.UpgradeFailureError) ->
         {:stop, {:shutdown, error}, state}
 
-      {:error, _conn, %Mint.TransportError{reason: :closed} = error, []} ->
+      {:error, _conn, %{reason: :closed} = error, []}
+      when is_struct(error, Mint.TransportError) ->
         {:stop, {:shutdown, error}, state}
 
       other ->


### PR DESCRIPTION
### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
