### PR TITLE
fix: truncate full error if it exceeds discord limit

### DIFF
--- a/test/disco_log/integrations/oban_test.exs
+++ b/test/disco_log/integrations/oban_test.exs
@@ -40,6 +40,9 @@ defmodule DiscoLog.ObanTest do
                    content: "**Kind:** `RuntimeError`\n**Reason:** `Exception!`" <> _
                  },
                  %{
+                   content: "```\n** (RuntimeError) Exception!\n" <> _
+                 },
+                 %{
                    type: 10,
                    content:
                      "```elixir\n%{\n  \"oban\" => %{\n    \"args\" => %{foo: \"bar\"},\n    \"attempt\" => 1,\n    \"id\" => 123,\n    \"priority\" => 1,\n    \"queue\" => :default,\n    \"state\" => :failure,\n    \"worker\" => :\"Test.Worker\"\n  }\n}\n```"

--- a/test/disco_log/integrations/plug_test.exs
+++ b/test/disco_log/integrations/plug_test.exs
@@ -58,6 +58,7 @@ defmodule DiscoLog.PlugTest do
                        **Source:** \
                        """ <> _
                    },
+                   %{},
                    %{}
                  ]
                }
@@ -97,6 +98,7 @@ defmodule DiscoLog.PlugTest do
                        **Source:** \
                        """ <> _
                    },
+                   %{},
                    %{}
                  ]
                }
@@ -136,6 +138,7 @@ defmodule DiscoLog.PlugTest do
                        **Source:** \
                        """ <> _
                    },
+                   %{},
                    %{}
                  ]
                }
@@ -174,6 +177,7 @@ defmodule DiscoLog.PlugTest do
                        **Source:** \
                        """ <> _
                    },
+                   %{},
                    %{}
                  ]
                }
@@ -209,6 +213,7 @@ defmodule DiscoLog.PlugTest do
                        **Source:** \
                        """ <> _
                    },
+                   %{},
                    %{}
                  ]
                }
@@ -243,6 +248,7 @@ defmodule DiscoLog.PlugTest do
                        **Reason:** `** (exit) \"i quit\"`\
                        """ <> _
                    },
+                   %{},
                    %{}
                  ]
                }

--- a/test/disco_log/logger_handler_test.exs
+++ b/test/disco_log/logger_handler_test.exs
@@ -363,6 +363,7 @@ defmodule DiscoLog.LoggerHandlerTest do
                applied_tags: [],
                message: %{
                  components: [
+                   %{content: _message},
                    %{content: message}
                  ]
                },
@@ -392,6 +393,7 @@ defmodule DiscoLog.LoggerHandlerTest do
                applied_tags: [],
                message: %{
                  components: [
+                   %{content: _message},
                    %{content: message}
                  ]
                },
@@ -423,6 +425,7 @@ defmodule DiscoLog.LoggerHandlerTest do
                applied_tags: [],
                message: %{
                  components: [
+                   %{content: _message},
                    %{content: message}
                  ]
                },
@@ -452,6 +455,7 @@ defmodule DiscoLog.LoggerHandlerTest do
                applied_tags: [],
                message: %{
                  components: [
+                   %{content: _message},
                    %{content: message}
                  ]
                },
@@ -481,6 +485,7 @@ defmodule DiscoLog.LoggerHandlerTest do
                applied_tags: [],
                message: %{
                  components: [
+                   %{content: _message},
                    %{content: message}
                  ]
                },
@@ -510,6 +515,7 @@ defmodule DiscoLog.LoggerHandlerTest do
                applied_tags: [],
                message: %{
                  components: [
+                   %{content: _message},
                    %{content: message}
                  ]
                },
@@ -546,6 +552,7 @@ defmodule DiscoLog.LoggerHandlerTest do
                applied_tags: [],
                message: %{
                  components: [
+                   %{content: _message},
                    %{content: message}
                  ]
                },
@@ -586,6 +593,7 @@ defmodule DiscoLog.LoggerHandlerTest do
                applied_tags: [],
                message: %{
                  components: [
+                   %{content: _message},
                    %{content: message}
                  ]
                },
@@ -624,6 +632,7 @@ defmodule DiscoLog.LoggerHandlerTest do
                applied_tags: [],
                message: %{
                  components: [
+                   %{content: _message},
                    %{content: message}
                  ]
                },
@@ -654,6 +663,7 @@ defmodule DiscoLog.LoggerHandlerTest do
                applied_tags: [],
                message: %{
                  components: [
+                   %{content: _},
                    %{content: message}
                  ]
                },
@@ -711,6 +721,7 @@ defmodule DiscoLog.LoggerHandlerTest do
                applied_tags: [],
                message: %{
                  components: [
+                   %{content: _message},
                    %{content: message}
                  ]
                },
@@ -746,6 +757,7 @@ defmodule DiscoLog.LoggerHandlerTest do
                applied_tags: [],
                message: %{
                  components: [
+                   %{content: _message},
                    %{content: message}
                  ]
                },
@@ -791,6 +803,7 @@ defmodule DiscoLog.LoggerHandlerTest do
                applied_tags: [],
                message: %{
                  components: [
+                   _,
                    _,
                    %{type: 10, content: "```elixir\n%{extra: \"hello\", foo: \"bar\"}\n```"}
                  ]

--- a/test/disco_log_test.exs
+++ b/test/disco_log_test.exs
@@ -58,6 +58,7 @@ defmodule DiscoLogTest do
                          message: %{
                            components: [
                              _,
+                             _,
                              %{content: "```elixir\n%{hello: \"world\", live_view: \"foo\"}\n```"}
                            ]
                          }


### PR DESCRIPTION
### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [x] Bug fixes include regression tests

The reason constraint error wasn't pushed to Discord in demo app is because it exceeded 4000 characters limits. This PR gives full error the same treatment as context - if it fits within the length budget it is appended to the main message body. if it doesn't, it is attached as a file.
